### PR TITLE
Delete release_max_level_off feature for log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ io-uring = {version="=0.7.4", features = ["bindgen", "overwrite"]}
 serde = {version = "1.0.99", features = ["derive"]}
 serde_json = "1.0.79"
 bitmaps = "3.2.0"
-log = {version = "0.4", features = ["release_max_level_off"]}
+log = "0.4"
 thiserror = "1.0.43"
 smol = "2.0.2"
 slab = "0.4.9"


### PR DESCRIPTION
This line in libublk's Cargo.toml makes it impossible to use the `log` crate from any application that depends on `libublk`, which seems misconceived.

Per `log`'s documentation:

> **Libraries should avoid using the max level features because they’re global and can’t be changed once they’re set.**