### PR TITLE
Fix `PR_SET_IO_FLUSHER` to set the flag instead of clearing it

### DIFF
--- a/src/ctrl.rs
+++ b/src/ctrl.rs
@@ -2565,7 +2565,7 @@ impl UblkCtrl {
         // Set IO flusher property for the queue thread
         unsafe {
             const PR_SET_IO_FLUSHER: i32 = 57; // include/uapi/linux/prctl.h
-            libc::prctl(PR_SET_IO_FLUSHER, 0, 0, 0, 0);
+            libc::prctl(PR_SET_IO_FLUSHER, 1, 0, 0, 0);
         }
 
         tid
@@ -2695,6 +2695,14 @@ mod tests {
     use std::cell::Cell;
     use std::path::Path;
     use std::rc::Rc;
+
+    #[test]
+    fn test_init_queue_thread_io_flusher() {
+        const PR_GET_IO_FLUSHER: i32 = 58; // include/uapi/linux/prctl.h
+
+        UblkCtrl::init_queue_thread();
+        assert_eq!(unsafe { libc::prctl(PR_GET_IO_FLUSHER, 0, 0, 0, 0) }, 1);
+    }
 
     #[test]
     fn test_ublk_get_features() {


### PR DESCRIPTION
Fixes: https://github.com/ublk-org/libublk-rs/issues/54

Existing code is doing this - 

```
libc::prctl(PR_SET_IO_FLUSHER, 0, 0, 0, 0);
```

It should be _setting_ the state to `1` - 

```
libc::prctl(PR_SET_IO_FLUSHER, 1, 0, 0, 0);
```

From https://man7.org/linux/man-pages/man2/pr_set_io_flusher.2const.html -

> `int prctl(PR_SET_IO_FLUSHER, long state, 0L, 0L, 0L);`
>
> If a user process is involved in the block layer or filesystem I/O
> path, and can allocate memory while processing I/O requests it
> **must set state to 1**.  This will put the process in the IO_FLUSHER
> state, which allows it special treatment to make progress when
> allocating memory.  If state is 0, the process will clear the
> IO_FLUSHER state, and the default behavior will be used.

